### PR TITLE
Update build workflow for new DuckDB release (v1.5.2)

### DIFF
--- a/.github/workflows/dist_pipeline.yml
+++ b/.github/workflows/dist_pipeline.yml
@@ -29,10 +29,10 @@ jobs:
       exclude_archs: "windows_amd64_mingw;osx_amd64;wasm_mvp;wasm_eh;wasm_threads"
 
   duckdb-stable-build:
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.1
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.2
     with:
-      duckdb_version: v1.5.1
-      ci_tools_version: v1.5.1
+      duckdb_version: v1.5.2
+      ci_tools_version: v1.5.2
       extension_name: infera
       enable_rust: true
       exclude_archs: "windows_amd64_mingw;osx_amd64;wasm_mvp;wasm_eh;wasm_threads"


### PR DESCRIPTION
* Updated build workflow for new DuckDB release (`v1.5.2`)